### PR TITLE
Fix inline keyboard for start command

### DIFF
--- a/texts/button/es.php
+++ b/texts/button/es.php
@@ -12,18 +12,18 @@ return [
         ['text' => 'Cerrar',        'callback_data' => 'cerrar'],
         ['text' => 'xCommerce [☁️]', 'callback_data' => 'xcommerce'],
     ],
-
+    // Fila 3
     [
-        [
-            ['text' => 'Auth',           'callback_data' => 'auth'],
-            ['text' => 'Charge',         'callback_data' => 'charge'],
-            ['text' => 'CCN Gates',      'callback_data' => 'ccngates'],
-        ],
-        [
-            ['text' => 'Mass Checking',  'callback_data' => 'masschecking'],
-        ],
-        [
-            ['text' => 'Back',           'callback_data' => 'back_start'],
-        ],
-        ]
-    ];
+        ['text' => 'Auth',           'callback_data' => 'auth'],
+        ['text' => 'Charge',         'callback_data' => 'charge'],
+        ['text' => 'CCN Gates',      'callback_data' => 'ccngates'],
+    ],
+    // Fila 4
+    [
+        ['text' => 'Mass Checking',  'callback_data' => 'masschecking'],
+    ],
+    // Fila 5
+    [
+        ['text' => 'Back',           'callback_data' => 'back_start'],
+    ],
+];


### PR DESCRIPTION
## Summary
- fix button layout to send a valid inline keyboard when handling `/start`

## Testing
- `php -l` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68471bf1848c8330af68e4c3e3ddd855